### PR TITLE
DO NOT MERGE;Native module changes for bundletool#130

### DIFF
--- a/DynamicFeatures/features/native/src/main/AndroidManifest.xml
+++ b/DynamicFeatures/features/native/src/main/AndroidManifest.xml
@@ -20,9 +20,12 @@
     package="com.google.android.samples.dynamicfeatures.ondemand.ccode">
 
     <dist:module
-        dist:onDemand="true"
+        dist:onDemand="false"
         dist:title="@string/module_native">
         <dist:fusing dist:include="true" />
+        <dist:device-feature	
+		dist:name="android.hardware.opengles.version"	
+		dist:version="0x00030001"/>
     </dist:module>
 
     <application>


### PR DESCRIPTION
Native is no longer on demand and has a
OpenGL version requirement.