### PR TITLE
Version bump to constraintLayout, PlayCore - Reduce minSDK

### DIFF
--- a/DynamicFeatures/app/build.gradle
+++ b/DynamicFeatures/app/build.gradle
@@ -65,7 +65,7 @@ dependencies {
 
     api "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
     api "androidx.appcompat:appcompat:${versions.appcompat}"
-    api 'androidx.constraintlayout:constraintlayout:1.1.3'
+    api 'androidx.constraintlayout:constraintlayout:2.0.0'
     api 'com.google.android.material:material:1.0.0'
     api "com.google.android.play:core:${versions.playcore}"
 

--- a/DynamicFeatures/build.gradle
+++ b/DynamicFeatures/build.gradle
@@ -23,7 +23,7 @@ buildscript {
             'minSdk'            : 24,
             'targetSdk'         : 28,
             'kotlin'            : '1.3.61',
-            'playcore'          : '1.6.4',
+            'playcore'          : '1.8.3',
             'appcompat'         : '1.1.0',
             'espresso'          : '3.2.0',
             'extJunit'          : '1.1.1',

--- a/DynamicFeatures/build.gradle
+++ b/DynamicFeatures/build.gradle
@@ -20,7 +20,7 @@ buildscript {
 
     ext.versions = [
             'compileSdk'        : 28,
-            'minSdk'            : 24,
+            'minSdk'            : 21,
             'targetSdk'         : 28,
             'kotlin'            : '1.3.61',
             'playcore'          : '1.8.3',


### PR DESCRIPTION
ConstraintLayout 1.1.3 contains a bug on Android versions L and M which crashes the app.