### PR TITLE
Fixed issue with unresolved initialInstall module.

### DIFF
--- a/DynamicFeatures/app/src/main/res/values/feature_names.xml
+++ b/DynamicFeatures/app/src/main/res/values/feature_names.xml
@@ -24,9 +24,10 @@
     <string name="module_large">large</string>
     <string name="module_feature_maxsdk">maxSdk</string>
     <string name="module_native">native</string>
-    <string name="module_initial">initial</string>
+    <string name="module_initial">initialInstall</string>
     <string name="module_instant_feature_split_install">split</string>
     <string name="instant_feature_url">http://uabsample-405d6.firebaseapp.com/url</string>
+    <string name="title_module_initial">initial</string>
     <string name="title_url_instant_module">url</string>
     <string name="title_activity_url_instant_module">url_instant_module_activity</string>
 </resources>

--- a/DynamicFeatures/features/initialInstall/src/main/AndroidManifest.xml
+++ b/DynamicFeatures/features/initialInstall/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
     package="com.google.android.samples.dynamicfeatures.initialinstall">
 
     <dist:module
-        dist:title="@string/module_initial">
+        dist:title="@string/title_module_initial">
         <dist:fusing dist:include="true" />
         <dist:delivery>
             <dist:install-time />


### PR DESCRIPTION
Currently, nothing happens when the user clicks on the "Launch Initially Installed feature" button. This is because the module name used by `splitInstallManager.installedModules` API (_initialInstall_) was not in sync with the requested one (_initial_).